### PR TITLE
Allow the deploy-check to fail so we can report it's results

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,11 +67,14 @@ jobs:
       - run:
           name: "Run Gradle tests [<<pipeline.parameters.e2e_environment>>]"
           command: |
+            set +e
             SERENITY_USERNAME=${SERENITY_USERNAME_<<pipeline.parameters.e2e_environment>>} \
             SERENITY_PASSWORD=${SERENITY_PASSWORD_<<pipeline.parameters.e2e_environment>>} \
             NOMS_NUMBER=${NOMS_NUMBER_<<pipeline.parameters.e2e_environment>>} \
             ./gradlew test -Denvironment=${ENVIRONMENT}
             export E2E_RESULT=$?
+            set -e
+
             ./report-results-to-dashboard.sh
             exit $E2E_RESULT
       - store_artifacts:


### PR DESCRIPTION
This is needed as CircleCI was exiting before it got to the bit reporting the failure to our dashboard