### PR TITLE
PUD-1263: Replace `localstack` with `minio`.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,14 +95,14 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - v1-deps-{{ .Branch }}-{{ checksum "package.json" }}
-            - v1-deps-{{ .Branch }}
-            - v1-deps
+            - v2-deps-{{ .Branch }}-{{ checksum "package.json" }}
+            - v2-deps-{{ .Branch }}
+            - v2-deps
       - run:
           name: Install Dependencies
           command: npm ci
       - save_cache:
-          key: v1-deps-{{ .Branch }}-{{ checksum "package.json" }}
+          key: v2-deps-{{ .Branch }}-{{ checksum "package.json" }}
           # cache NPM modules and the folder with the Cypress binary
           paths:
             - ~/.npm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
             mkdir logs
             docker logs manage-recalls-ui-e2e > logs/manage-recalls-ui.log
             docker logs manage-recalls-api-e2e > logs/manage-recalls-api.log
-            docker logs localstack_manage-recalls-e2e > logs/localstack_manage-recalls-e2e.log
+            docker logs minio_manage-recalls-e2e > logs/minio_manage-recalls-e2e.log
             docker cp manage-recalls-e2e-test-runner:/home/circleci/project/build/reports/tests/test/ test-report
             docker cp manage-recalls-e2e-test-runner:/home/circleci/project/target/site/serenity/ serenity-report
             exit $exit_code

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,7 @@ services:
     networks:
       - manage-recalls-e2e
     container_name: manage-recalls-api-e2e
-    depends_on: [gotenberg, fake-prisoner-offender-search-api, fake-prison-register-api, fake-court-register-api, postgres, localstack]
+    depends_on: [gotenberg, fake-prisoner-offender-search-api, fake-prison-register-api, fake-court-register-api, postgres, minio]
     ports:
       - "9091:8080"
     healthcheck:
@@ -88,7 +88,7 @@ services:
       - POSTGRES_DBNAME=manage_recalls
       - POSTGRES_USERNAME=ppud_user
       - POSTGRES_PASSWORD=secret
-      - AWS_LOCAL_ENDPOINT=http://localstack:4566
+      - AWS_LOCAL_ENDPOINT=http://minio:4566
 
   manage-recalls-ui:
     image: quay.io/hmpps/manage-recalls-ui:latest
@@ -125,17 +125,20 @@ services:
       - POSTGRES_USER=ppud_user
       - POSTGRES_DB=manage_recalls
 
-  localstack:
-    build: ./localstack-docker
+  minio:
+    image: minio/minio:latest
+    container_name: minio_manage-recalls-e2e
     ports:
-      - "4566:4566"
-      - "4571:4571"
+      - 4566:4566
+      - 9001:9001
+    environment:
+      - MINIO_ROOT_USER=ANYTHING_GOES
+      - MINIO_ROOT_PASSWORD=ANYTHING_GOES
+      - MINIO_DEFAULT_BUCKETS=test-manage-recalls-api
     networks:
       - manage-recalls-e2e
-    container_name: localstack_manage-recalls-e2e
-    environment:
-      - SERVICES=s3
-      - INIT_SCRIPTS_PATH=/tmp/localstack
+    entrypoint: sh
+    command: -c 'mkdir -p /data/test-manage-recalls-api && /opt/bin/minio server /data --address ":4566" --console-address ":9001"'
 
   clamav:
     image: ghcr.io/ministryofjustice/hmpps-clamav-freshclammed

--- a/localstack-docker/Dockerfile
+++ b/localstack-docker/Dockerfile
@@ -1,3 +1,0 @@
-FROM localstack/localstack:latest
-
-COPY scripts /tmp/localstack

--- a/localstack-docker/scripts/01_create_bucket.sh
+++ b/localstack-docker/scripts/01_create_bucket.sh
@@ -1,4 +1,0 @@
-export AWS_ACCESS_KEY_ID=dontcare
-export AWS_SECRET_ACCESS_KEY=dontcare
-
-aws s3api create-bucket --bucket test-manage-recalls-api --region eu-west-2 --endpoint-url http://localhost:4566

--- a/start-local-services.sh
+++ b/start-local-services.sh
@@ -11,27 +11,26 @@ readonly MANAGE_RECALLS_UI_LOG_FILE="/tmp/${MANAGE_RECALLS_UI_NAME}-e2e.log"
 readonly MANAGE_RECALLS_API_LOG_FILE="/tmp/${MANAGE_RECALLS_API_NAME}-e2e.log"
 readonly LOCAL_DOCKER_COMPOSE_FILE=docker-compose.yml
 
-docker compose -f $LOCAL_DOCKER_COMPOSE_FILE build localstack
-docker compose -f $LOCAL_DOCKER_COMPOSE_FILE pull redis gotenberg hmpps-auth fake-prisoner-offender-search-api fake-prison-register-api fake-court-register-api postgres localstack
-docker compose -f $LOCAL_DOCKER_COMPOSE_FILE up redis gotenberg hmpps-auth fake-prisoner-offender-search-api fake-prison-register-api fake-court-register-api postgres localstack --remove-orphans -d
+docker compose -f $LOCAL_DOCKER_COMPOSE_FILE pull redis gotenberg hmpps-auth fake-prisoner-offender-search-api fake-prison-register-api fake-court-register-api postgres minio
+docker compose -f $LOCAL_DOCKER_COMPOSE_FILE up redis gotenberg hmpps-auth fake-prisoner-offender-search-api fake-prison-register-api fake-court-register-api postgres minio --remove-orphans -d
 
 npx kill-port 3000 8080
 
 pushd ${MANAGE_RECALLS_UI_DIR}
 npm run clean
 npm run build
-npm run start:e2e >> "${MANAGE_RECALLS_UI_LOG_FILE}" 2>&1 &
+npm run start:e2e >>"${MANAGE_RECALLS_UI_LOG_FILE}" 2>&1 &
 popd
 
 pushd ${MANAGE_RECALLS_API_DIR}
-SPRING_PROFILES_ACTIVE=dev ./gradlew bootRun >> "${MANAGE_RECALLS_API_LOG_FILE}" 2>&1 &
+SPRING_PROFILES_ACTIVE=dev ./gradlew bootRun >>"${MANAGE_RECALLS_API_LOG_FILE}" 2>&1 &
 popd
 
 printf "\nChecking hmpps-auth is running..."
 curl -s -4 --retry 40 --retry-delay 2 --retry-connrefused http://localhost:9090/auth/health/ping
 
 printf "\nChecking ${MANAGE_RECALLS_API_NAME} is running..."
-curl -s -4 --retry 20 --retry-delay 1 --retry-connrefused http://localhost:8080/health/ping
+curl -s -4 --retry 20 --retry-delay 2 --retry-connrefused http://localhost:8080/health/ping
 
 printf "\nChecking ${MANAGE_RECALLS_UI_NAME} is running..."
 curl -s -4 --retry 20 --retry-delay 1 --retry-connrefused http://localhost:3000/ping


### PR DESCRIPTION
MinIO is an S3 compatible distributed object store, but it starts up and tears down much faster than localstack.

I've configured MinIO to use the same ports etc as localstack would have so there's no need to change any configuration in manage-recalls-api.

EDIT: I didn't use `fake-s3` in the end as this now requires a license to use in a commercial setting.