### PR TITLE
Use the real postcode API when running locally with e2e.env

### DIFF
--- a/start-local-services.sh
+++ b/start-local-services.sh
@@ -11,8 +11,8 @@ readonly MANAGE_RECALLS_UI_LOG_FILE="/tmp/${MANAGE_RECALLS_UI_NAME}-e2e.log"
 readonly MANAGE_RECALLS_API_LOG_FILE="/tmp/${MANAGE_RECALLS_API_NAME}-e2e.log"
 readonly LOCAL_DOCKER_COMPOSE_FILE=docker-compose.yml
 
-docker compose -f $LOCAL_DOCKER_COMPOSE_FILE pull redis gotenberg hmpps-auth fake-prisoner-offender-search-api fake-prison-register-api fake-court-register-api fake-os-places-api postgres minio
-docker compose -f $LOCAL_DOCKER_COMPOSE_FILE up redis gotenberg hmpps-auth fake-prisoner-offender-search-api fake-prison-register-api fake-court-register-api fake-os-places-api postgres minio --remove-orphans -d
+docker compose -f $LOCAL_DOCKER_COMPOSE_FILE pull redis gotenberg hmpps-auth fake-prisoner-offender-search-api fake-prison-register-api fake-court-register-api postgres minio
+docker compose -f $LOCAL_DOCKER_COMPOSE_FILE up redis gotenberg hmpps-auth fake-prisoner-offender-search-api fake-prison-register-api fake-court-register-api postgres minio --remove-orphans -d
 
 npx kill-port 3000 8080
 


### PR DESCRIPTION
`./start-local-services` is used to run both the E2E locally and also for local development, so having actual postcode lookup results returned from the OS Places API enables testing of more scenarios. 
For the `local-check` E2E tests, a canned API response continues to be used.