### PR TITLE
Add in new jobs/workflows to run the dev/preprod checks separately.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,36 +97,6 @@ jobs:
           path: cypress/reports
           destination: reports
 
-  deploy-check:
-    executor:
-      name: hmpps/node
-      tag: 16.13-browsers
-    environment:
-      ENVIRONMENT: <<pipeline.parameters.e2e_environment>>
-    steps:
-      - browser-tools/install-chrome
-      - browser-tools/install-chromedriver
-      - checkout
-      - run:
-          name: Update NPM to match package.json
-          command: sudo npm install -g npm@$(jq -r '.engines.npm' < package.json)
-      - node/install-packages
-      - run:
-          name: "Run Cypress tests [<<pipeline.parameters.e2e_environment>>]"
-          command: |
-            set +e
-            npx cypress run --env USERNAME=${CYPRESS_USERNAME_<<pipeline.parameters.e2e_environment>>},PASSWORD=${CYPRESS_PASSWORD_<<pipeline.parameters.e2e_environment>>},NOMS_NUMBER=${NOMS_NUMBER_<<pipeline.parameters.e2e_environment>>} --config baseUrl=https://manage-recalls-<<pipeline.parameters.e2e_environment>>.hmpps.service.justice.gov.uk --browser chrome
-            export E2E_RESULT=$?
-            npm run cypress:report
-            set -e
-            exit $E2E_RESULT
-      - store_artifacts:
-          path: cypress/screenshots
-          destination: screenshots
-      - store_artifacts:
-          path: cypress/reports
-          destination: reports
-
   check-env:
     executor:
       name: hmpps/node
@@ -147,9 +117,14 @@ jobs:
           name: "Run Cypress tests [<< parameters.environment >>]"
           command: |
             set +e
-            npx cypress run --env USERNAME=${CYPRESS_USERNAME_<< parameters.environment >>},PASSWORD=${CYPRESS_PASSWORD_<< parameters.environment >>},NOMS_NUMBER=${NOMS_NUMBER_<< parameters.environment >>} --config baseUrl=https://manage-recalls-<< parameters.environment >>.hmpps.service.justice.gov.uk --browser chrome
+
+            ./scripts/do-exclusively \
+              --job check-<< parameters.environment >> \
+              npx cypress run --env USERNAME=${CYPRESS_USERNAME_<< parameters.environment >>},PASSWORD=${CYPRESS_PASSWORD_<< parameters.environment >>},NOMS_NUMBER=${NOMS_NUMBER_<< parameters.environment >>} --config baseUrl=https://manage-recalls-<< parameters.environment >>.hmpps.service.justice.gov.uk --browser chrome
+
             export E2E_RESULT=$?
             npm run cypress:report
+
             set -e
             exit $E2E_RESULT
       - store_artifacts:
@@ -166,7 +141,16 @@ workflows:
       not: << pipeline.parameters.only_run_deploy_check >>
     jobs:
       - local-check
-      - deploy-check
+      - check-env:
+          name: check-dev
+          environment: dev
+
+  deploy_only:
+    when: << pipeline.parameters.only_run_deploy_check >>
+    jobs:
+      - check-env:
+          name: check-dev
+          environment: dev
 
   check-docker:
     when: << pipeline.parameters.check-docker >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,15 @@ parameters:
   e2e_environment:
     type: string
     default: dev
+  check-docker:
+    type: boolean
+    default: true
+  check-dev:
+    type: boolean
+    default: true
+  check-preprod:
+    type: boolean
+    default: false
 
 jobs:
   local-check:
@@ -92,7 +101,6 @@ jobs:
     executor:
       name: hmpps/node
       tag: 16.13-browsers
-    resource_class: large
     environment:
       ENVIRONMENT: <<pipeline.parameters.e2e_environment>>
     steps:
@@ -119,6 +127,38 @@ jobs:
           path: cypress/reports
           destination: reports
 
+  check-env:
+    executor:
+      name: hmpps/node
+      tag: 16.13-browsers
+    parameters:
+      environment:
+        type: string
+        default: dev
+    steps:
+      - browser-tools/install-chrome
+      - browser-tools/install-chromedriver
+      - checkout
+      - run:
+          name: Update NPM to match package.json
+          command: sudo npm install -g npm@$(jq -r '.engines.npm' < package.json)
+      - node/install-packages
+      - run:
+          name: "Run Cypress tests [<< parameters.environment >>]"
+          command: |
+            set +e
+            npx cypress run --env USERNAME=${CYPRESS_USERNAME_<< parameters.environment >>},PASSWORD=${CYPRESS_PASSWORD_<< parameters.environment >>},NOMS_NUMBER=${NOMS_NUMBER_<< parameters.environment >>} --config baseUrl=https://manage-recalls-<< parameters.environment >>.hmpps.service.justice.gov.uk --browser chrome
+            export E2E_RESULT=$?
+            npm run cypress:report
+            set -e
+            exit $E2E_RESULT
+      - store_artifacts:
+          path: cypress/screenshots
+          destination: screenshots
+      - store_artifacts:
+          path: cypress/reports
+          destination: reports
+
 workflows:
   version: 2
   dev_and_local:
@@ -127,7 +167,23 @@ workflows:
     jobs:
       - local-check
       - deploy-check
-  deploy_only:
-    when: << pipeline.parameters.only_run_deploy_check >>
+
+  check-docker:
+    when: << pipeline.parameters.check-docker >>
     jobs:
-      - deploy-check
+      - local-check:
+          name: check-docker
+
+  check-dev:
+    when: << pipeline.parameters.check-dev >>
+    jobs:
+      - check-env:
+          name: check-dev
+          environment: dev
+
+  check-preprod:
+    when: << pipeline.parameters.check-preprod >>
+    jobs:
+      - check-env:
+          name: check-preprod
+          environment: preprod

--- a/scripts/do-exclusively
+++ b/scripts/do-exclusively
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+# ref: https://github.com/shamaazi/circle-lock-test
+#  - this is a fork of https://github.com/bellkev/circle-lock-test that allows us
+#    to block and wait for a specific job to finish before starting...
+
+set -e
+set -u
+set -o pipefail
+
+branch=""
+tag=""
+declare -a job=()
+declare -a rest=()
+
+# Join an array by a string
+function join_by {
+  local d=$1
+  shift
+  echo -n "$1"
+  shift
+  printf "%s" "${@/#/$d}"
+}
+
+# sets $branch, $tag, $job, $rest
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case $1 in
+    -j | --job) job=("${job[@]}" "$2") ;;
+    -b | --branch) branch="$2" ;;
+    -t | --tag) tag="$2" ;;
+    *) break ;;
+    esac
+    shift 2
+  done
+  rest=("$@")
+}
+
+# reads $branch, $tag, $commit_message
+should_skip() {
+  if [[ "$branch" && "$CIRCLE_BRANCH" != "$branch" ]]; then
+    echo "Not on branch $branch. Skipping..."
+    return 0
+  fi
+
+  if [[ "$tag" && "$commit_message" != *\[$tag\]* ]]; then
+    echo "No [$tag] commit tag found. Skipping..."
+    return 0
+  fi
+
+  return 1
+}
+
+# reads $branch, $tag
+# sets $jq_prog
+make_jq_prog() {
+  local jq_filters=""
+
+  if [[ $branch ]]; then
+    jq_filters+=" and .branch == \"$branch\""
+  fi
+
+  if [[ $tag ]]; then
+    jq_filters+=" and (.subject | contains(\"[$tag]\"))"
+  fi
+
+  if [[ ${#job[@]} != 0 ]]; then
+    jq_filters+=" and (.workflows.job_name | test(\"$(join_by "|" "${job[@]}")\")) "
+  fi
+
+  jq_prog=".[] | select(.build_num < $CIRCLE_BUILD_NUM and (.status | test(\"running|pending|queued\")) $jq_filters) | .build_num"
+}
+
+api_url="https://circleci.com/api/v1/project/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME?circle-token=$CIRCLE_TOKEN&limit=100"
+
+parse_args "$@"
+commit_message=$(git log -1 --pretty=%B)
+if should_skip; then exit 0; fi
+make_jq_prog
+
+echo "Checking for running builds..."
+
+while true; do
+  builds=$(curl -s -H "Accept: application/json" "$api_url" | jq "$jq_prog")
+  if [[ $builds ]]; then
+    echo "Waiting on builds:"
+    echo "$builds"
+  else
+    break
+  fi
+  echo "Retrying in 10 seconds..."
+  sleep 10
+done
+
+echo "Acquired lock"
+
+if [[ "${#rest[@]}" -ne 0 ]]; then
+  "${rest[@]}"
+fi


### PR DESCRIPTION
This should allow us to run the checks for `dev` and `preprod` at the same time, but also ensure we only run one of each in parallel (my testing looks good). 🤞 

I'll need to update the way that the `api` and `ui` codebases call this before I can clean up the old workflows and remove some deprecated params - once they're done I'll clean up in a separate PR.