### PR TITLE
PUD-1377: API health/ping for start-local now on 8081

### DIFF
--- a/start-local-services.sh
+++ b/start-local-services.sh
@@ -35,7 +35,7 @@ function wait_for {
 }
 
 wait_for "http://localhost:9090/auth/health/ping" "hmpps-auth"
-wait_for "http://localhost:8080/health/ping" "${MANAGE_RECALLS_API_NAME}"
+wait_for "http://localhost:8081/health/ping" "${MANAGE_RECALLS_API_NAME}"
 wait_for "http://localhost:3000/ping" "${MANAGE_RECALLS_UI_NAME}"
 
 echo "Logs can be found by running:"


### PR DESCRIPTION
A one character change to allow start-local to detect API up!