### PR TITLE
Revert "Update Redis setup"

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -12,12 +12,10 @@
     "reporterEnabled": "spec, mocha-junit-reporter",
     "reporterOptions": {
       "mochaFile": "cypress/junit/results-[hash].xml"
-    },
-    "viewportHeight": 1080,
-    "viewportWidth": 1920
+    }
   },
   "retries": {
-    "runMode": 1,
+    "runMode": 2,
     "openMode": 0
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,27 +2,14 @@ version: '3.1'
 services:
 
   redis:
-    image: 'bitnami/redis:6.2'
+    image: 'bitnami/redis:5.0'
     networks:
       - manage-recalls-e2e
     container_name: redis-e2e
     environment:
-      - REDIS_PASSWORD=secret
+      - ALLOW_EMPTY_PASSWORD=yes
     ports:
       - '6379:6379'
-
-  redis-commander:
-    image: rediscommander/redis-commander:latest
-    container_name: redis-commander-e2e
-    depends_on: [redis]
-    networks:
-      - manage-recalls-e2e
-    environment:
-      - REDIS_HOST=redis
-      - REDIS_PORT=6379
-      - REDIS_PASSWORD=secret
-    ports:
-      - 9999:8081
 
   gotenberg:
     image: thecodingmachine/gotenberg:7.5.0
@@ -110,7 +97,7 @@ services:
       - "9091:8080"
       - "9081:8081"
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/health" ]
+      test: [ "CMD", "curl", "-f", "http://localhost:8080/health/ping" ]
     environment:
       - SERVER_PORT=8080
       - SPRING_PROFILES_ACTIVE=dev
@@ -142,7 +129,6 @@ services:
     environment:
       - NODE_ENV=dev
       - REDIS_HOST=redis
-      - REDIS_AUTH_TOKEN=secret
       - INGRESS_URL=http://localhost:3000
       - HMPPS_AUTH_EXTERNAL_URL=http://localhost:9090/auth
       - HMPPS_AUTH_URL=http://hmpps-auth:8080/auth

--- a/start-local-services.sh
+++ b/start-local-services.sh
@@ -35,8 +35,8 @@ function wait_for {
 }
 
 wait_for "http://localhost:9090/auth/health/ping" "hmpps-auth"
-wait_for "http://localhost:9091/health" "${MANAGE_RECALLS_API_NAME}"
-wait_for "http://localhost:3000/health" "${MANAGE_RECALLS_UI_NAME}"
+wait_for "http://localhost:8081/health/ping" "${MANAGE_RECALLS_API_NAME}"
+wait_for "http://localhost:3000/ping" "${MANAGE_RECALLS_UI_NAME}"
 
 echo "Logs can be found by running:"
 echo "  less ${MANAGE_RECALLS_API_LOG_FILE}"


### PR DESCRIPTION
Reverts ministryofjustice/manage-recalls-e2e-tests#207
Reverting commit which breaks local running of e2e dependencies, per Slack: https://mojdt.slack.com/archives/C025S4PG5FT/p1646139289566879