### PR TITLE
Fix the splitting of the E2E scenarios.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,6 +82,7 @@ jobs:
 
             export E2E_RESULT=$?
             npm run cypress:report
+            node scripts/fix-junit-reports.js
 
             set -e
             exit $E2E_RESULT
@@ -99,6 +100,9 @@ jobs:
       - store_artifacts:
           path: cypress/reports
           destination: reports
+      - store_artifacts:
+          path: cypress/junit
+          destination: junit
       - store_test_results:
           path: cypress/junit
 
@@ -144,6 +148,7 @@ jobs:
             echo "${CIRCLE_NODE_TOTAL}" > "workspace/env-output/TOTAL_NODES"
 
             npm run cypress:report
+            node scripts/fix-junit-reports.js
 
             # NOTE: We *always* exit cleanly here so we can report results, we'll use the exit code later
             exit 0
@@ -157,6 +162,9 @@ jobs:
       - store_artifacts:
           path: cypress/reports
           destination: reports
+      - store_artifacts:
+          path: cypress/junit
+          destination: junit
       - store_test_results:
           path: cypress/junit
 

--- a/cypress.json
+++ b/cypress.json
@@ -5,7 +5,7 @@
   "video": false,
   "reporter": "cypress-multi-reporters",
   "reporterOptions": {
-    "reportDir": "cypress/report",
+    "reportDir": "cypress/reports",
     "charts": true,
     "reportPageTitle": "Manage a recall E2E tests",
     "embeddedScreenshots": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "luxon": "^2.2.0",
         "mocha-junit-reporter": "^2.0.2",
         "multiple-cucumber-html-reporter": "^1.18.3",
-        "pdf-parse": "^1.1.1"
+        "pdf-parse": "^1.1.1",
+        "xml2js": "^0.4.23"
       },
       "engines": {
         "node": "16.13.2",
@@ -6416,6 +6417,12 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "node_modules/sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
+    },
     "node_modules/seed-random": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/seed-random/-/seed-random-2.2.0.tgz",
@@ -7452,6 +7459,28 @@
       "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
       "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
       "dev": true
+    },
+    "node_modules/xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "dev": true,
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -12471,6 +12500,12 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
+    },
     "seed-random": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/seed-random/-/seed-random-2.2.0.tgz",
@@ -13335,6 +13370,22 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
       "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
+      "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "dev": true,
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      }
+    },
+    "xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
       "dev": true
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "luxon": "^2.2.0",
     "mocha-junit-reporter": "^2.0.2",
     "multiple-cucumber-html-reporter": "^1.18.3",
-    "pdf-parse": "^1.1.1"
+    "pdf-parse": "^1.1.1",
+    "xml2js": "^0.4.23"
   },
   "cypress-cucumber-preprocessor": {
     "step_definitions": "cypress/integration/stepDefinitions/",

--- a/scripts/fix-junit-reports.js
+++ b/scripts/fix-junit-reports.js
@@ -1,0 +1,36 @@
+const fs = require("fs")
+const parseString = require("xml2js").parseString
+const xml2js = require("xml2js")
+
+fs.readdir("./cypress/junit", (err, files) => {
+  if (err) {
+    return console.log(err)
+  }
+  files.forEach((file) => {
+    const filePath = `./cypress/junit/${file}`
+    fs.readFile(filePath, "utf8", (err, data) => {
+      if (err) {
+        return console.log(err)
+      }
+
+      parseString(data, (err, xml) => {
+        if (err) {
+          return console.log(err)
+        }
+
+        const file = xml.testsuites.testsuite[0].$.file
+        xml.testsuites.testsuite.forEach((testsuite, index) => {
+          if (index > 0) {
+            testsuite.$.file = file
+          }
+        })
+
+        const builder = new xml2js.Builder()
+        const xmlOut = builder.buildObject(xml)
+        fs.writeFile(filePath, xmlOut, (err) => {
+          if (err) throw err
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
The (junit format) result XML we pass onto CircleCI was missing the
filename information for each individual test so we weren't correctly
splitting the scenarios based on timing.

The added script fixes the generated XML files.

ref: https://github.com/michaelleeallen/mocha-junit-reporter/issues/132#issuecomment-721943600